### PR TITLE
添加图片识别错误时的报错处理

### DIFF
--- a/shebot/concatHead/__init__.py
+++ b/shebot/concatHead/__init__.py
@@ -50,12 +50,15 @@ async def concat_head(bot: HoshinoBot, ev: CQEvent):
         async with session.get(url) as resp:
             cont = await resp.read()
             b64 = (base64.b64encode(cont)).decode()
-            img = Image.open(BytesIO(cont))
-
     face_data_list = await detect_face(b64)
     #print(face_data_list)
-    if not face_data_list:
-        await bot.finish(ev, '未检测到人脸信息')
+    try:
+        img = Image.open(BytesIO(cont))
+    except:
+        await bot.finish(ev,'暂时不支持二次元图片接头哦~')
+    else:
+        if not face_data_list:
+            await bot.finish(ev, '未检测到人脸信息')
 
     uid = ev.user_id
     head_name = user_conf_dic.get(uid, 'auto')

--- a/shebot/concatHead/__init__.py
+++ b/shebot/concatHead/__init__.py
@@ -54,7 +54,7 @@ async def concat_head(bot: HoshinoBot, ev: CQEvent):
     #print(face_data_list)
     try:
         img = Image.open(BytesIO(cont))
-    except:
+    except (UnidentifiedImageError):
         await bot.finish(ev,'暂时不支持二次元图片接头哦~')
     else:
         if not face_data_list:


### PR DESCRIPTION
在无法识别图片时（比如发送的为二次元图片）会出现报错且没有回复，所以添加了报错处理。