### PR TITLE
rua 透明背景

### DIFF
--- a/shebot/rua/data_source.py
+++ b/shebot/rua/data_source.py
@@ -19,14 +19,19 @@ def generate_gif(frame_dir: str, avatar: Image.Image) -> Image.Image:
     avatar_pos = [(50,150), (28,195), (5,217), (5,195), (50,128)]
     imgs = []
     for i in range(5):
-        im = Image.new(mode='RGBA', size=(600, 600), color='white')
+        im = Image.new(mode='RGBA', size=(600, 600))
         hand = Image.open(path.join(frame_dir, f'hand-{i+1}.png'))
         hand = hand.convert('RGBA')
         avatar = get_circle_avatar(avatar, 350)
         avatar = avatar.resize(avatar_size[i])
         im.paste(avatar, avatar_pos[i], mask=avatar.split()[3])
         im.paste(hand, mask=hand.split()[3])
+        mask = im.split()[3]
+        mask = Image.eval(mask, lambda a: 255 if a <= 50 else 0)
+        im = im.convert('RGB').convert('P', palette=Image.ADAPTIVE, colors=255)
+        im.paste(255, mask)
         imgs.append(im)
     out_path = path.join(frame_dir, 'output.gif')
-    imgs[0].save(fp=out_path, save_all=True, append_images=imgs, duration=25, loop=0, quality=80)
+    imgs[0].save(fp=out_path, save_all=True, append_images=imgs,
+                 duration=25, loop=0, quality=80, transparency=255, disposal=3)
     return out_path


### PR DESCRIPTION
让rua的背景变透明
[查了下](http://www.pythonclub.org/modules/pil/convert-png-gif)说是gif其实是指定一种颜色为透明（就是transparency参数指定的颜色）
所以可以只用255种颜色表示原图像，剩下的最后一种颜色作为透明色
不过有个代价，花费时间好像变长了不少（
效果：
![output](https://user-images.githubusercontent.com/43800204/109387942-1ceb1100-793f-11eb-9615-70a0f52e22d1.gif)
